### PR TITLE
Fixes potential Python 3.5+ compatibility issues

### DIFF
--- a/af-mirrors.py
+++ b/af-mirrors.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from subprocess import Popen, PIPE, STDOUT, STDERR
+from subprocess import Popen, PIPE, STDOUT
 import os
 from shlex import shlex, quote
 import sys
@@ -12,9 +12,9 @@ if not os.geteuid() == 0:
     sys.exit("\nOnly root can run this script\n")
 
 popen_args = {
-    universal_newlines: True,
-    stdout: PIPE,
-    stderr: STDOUT,
+    "universal_newlines": True,
+    "stdout": PIPE,
+    "stderr": STDOUT,
 }
 
 # decide repo to use


### PR DESCRIPTION
I discovered and fixed these discrepancies while attempting to use af-mirrors.py in a Docker container based on Debian stretch.

I encountered problems running this on Pythons 2.17.7, 3.5.3, and 3.9.0. The primary target is 3.5.3, which apparently 

* lacks subprocess.STDERR, which appears to be unused, and
* needs the dictionary to be quoted

These changes enable Python 3.5.3 compatibility.

I should note that I needed to ensure the presence of two packages: `apt-get install -y lsb-release netselect-apt`. I suspect most desktop or server installations already have them but my base container does not.