### PR TITLE
 refactor script to use subprocess for lsb_release and enhance readability with black formatting

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,0 +1,14 @@
+name: Lint (Black)
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./"
+          version: "~= 22.0"

--- a/README.org
+++ b/README.org
@@ -1,34 +1,40 @@
 * apt-fast-mirrors
 A fastest mirror selector for apt-fast. Currently only works on Debian
 
-run `sudo python3 af-mirrors.py` to fetch the fastest mirrors and add the 10 fastest to the `MIRRORS` variable in `/etc/apt-fast.conf`.
+To fetch the fastest mirrors and add the 10 fastest to the `MIRRORS` variable in `/etc/apt-fast.conf`, run:
+
+#+BEGIN_SRC bash
+sudo python3 af-mirrors.py
+#+END_SRC
 
 The fastest mirror is also added to `/etc/apt/sources.list.d/sources_<repo>.list`.
 
-* Prerequisites
+** Prerequisites
 
-Install apt-fast
+*** Install apt-fast
 
 #+BEGIN_SRC bash
 sudo add-apt-repository ppa:apt-fast/stable
 sudo apt-get update
-sudo apt-get install -y apt-fast
+sudo apt-get install apt-fast
 #+END_SRC
 
-Install dependencies
+*** Install dependencies
+
+To ensure the script functions as intended, install `lsb-release`, `netselect-apt`, and `netselect`:
 
 #+BEGIN_SRC bash
-sudo apt-get install -y lsb-release netselect-apt netselect
+sudo apt-fast install lsb-release netselect-apt netselect
 #+END_SRC
 
-** Netselect on Ubuntu
+**** Netselect on Ubuntu
 
-netselect and netselect-apt are not in the Ubuntu repositories. The deb packages can be downloaded from Debian Repo
+`netselect` and `netselect-apt` are not available in the Ubuntu repositories by default. They can be installed by downloading the Debian packages and installing them manually:
 
 #+BEGIN_SRC bash
-wget http://ftp.debian.org/debian/pool/main/n/netselect/netselect_0.3.ds1-28+b1_amd64.deb
-wget http://ftp.debian.org/debian/pool/main/n/netselect/netselect-apt_0.3.ds1-26_all.deb
+wget http://ftp.debian.org/debian/pool/main/n/netselect/netselect_0.3.ds1-30.1_amd64.deb
+wget http://ftp.debian.org/debian/pool/main/n/netselect/netselect-apt_0.3.ds1-30.1_all.deb
 
-sudo dpkg -i netselect_0.3.ds1-28+b1_amd64.deb
-sudo dpkg -i netselect-apt_0.3.ds1-26_all.deb
+sudo dpkg -i netselect_0.3.ds1-30.1_amd64.deb
+sudo dpkg -i netselect-apt_0.3.ds1-30.1_all.deb
 #+END_SRC

--- a/af-mirrors.py
+++ b/af-mirrors.py
@@ -54,7 +54,8 @@ process = run(
     stdout=PIPE,
     stderr=STDOUT,
     env=os.environ
-
+)
+    
 mirrors = []
 state = "fastest"
 

--- a/af-mirrors.py
+++ b/af-mirrors.py
@@ -46,28 +46,24 @@ print("Searching for fastest mirrors...")
 
 # use netselect-apt to find fastest debian mirrors
 process = run(
-    [
-        "/usr/bin/netselect-apt", repo, "-n", "-s",
-        "-o /etc/apt/sources.list.d/sources_stable.list"
-    ],
+    ["/usr/bin/netselect-apt", repo, "-n", "-s", "-o", "/etc/apt/sources.list.d/sources_stable.list"],
     text=True,
     stdout=PIPE,
     stderr=STDOUT,
     env=os.environ
 )
-    
+
 mirrors = []
 state = "fastest"
 
 # parse netselect-apt output for mirrors
-for line in p.stdout.readlines():
+for line in process.stdout.splitlines():
     if state == "fastest" and "fastest" in line:
         state = "http"
     elif state == "http":
         match = re.match("\s*(http\S+)", line)
         if match:
             mirrors.append(match.group(1))
-            print(match.group(1))
         elif "Of the hosts" in line:
             state = "finished"
 
@@ -92,36 +88,45 @@ def judge_mirror(entry):
 
 
 found_mirrors = False
-in_mirrors = False
-mirror_toks = []
+new_content = []
+in_mirrors_section = False
+mirrors_updated = False
 advert = '# Mirrors obtained from apt-fast-mirrors\n'
 
-with fileinput.input("/etc/apt-fast.conf", inplace=True) as f:
-    for line in f:
-        if not in_mirrors:
-            tokens = line.split()
-            match tokens:
-                case ['MIRRORS', '=', '(']:
-                    if found_mirrors:
-                        sys.stderr.write("apt-fast.conf has than one MIRRORS.")
-                    found_mirrors = True
-                    in_mirrors = True
-                    print(advert, end='')
-                    print('MIRRORS=(', end='')
-                case _:
-                    print(line, end='')
-        else:
-            tokens = line.strip().split()
-            match tokens:
-                case [')']:
-                    in_mirrors = False
-                    print(' '.join(quote(judge_mirror(mirror)[0]) for mirror in mirror_toks) + ' )')
-                    mirror_toks = []
-                case _:
-                    mirror_toks.extend(tokens)
+# proccess apt-fast.conf
+for line in fileinput.input("/etc/apt-fast.conf", inplace=False):
+    stripped_line = line.strip()
+    if stripped_line.startswith("MIRRORS=(") and not mirrors_updated:
+        # found MIRRORS line
+        print("Updating MIRRORS in /etc/apt-fast.conf.")
 
-# if no MIRRORS was found in apt-fast.conf, append one to the end
+        in_mirrors_section = True
+        found_mirrors = True
+        new_content.append(advert)
+        new_content.append('MIRRORS=(')
+        new_content.append(' '.join(quote(mirror) for mirror in mirrors) + ' )')
+        mirrors_updated = True
+    elif in_mirrors_section and stripped_line.endswith(")"):
+        # end of MIRRORS section; skip appending this line to prevent duplicate
+        in_mirrors_section = False
+        continue
+    elif not in_mirrors_section:
+        # for lines outside the MIRRORS section, add them to the new content as is
+        new_content.append(line.rstrip('\n'))
+
+# check if MIRRORS was found; if not, append it
 if not found_mirrors:
-    print("couldn't find MIRRORS var, appending one to the end")
-    with open("/etc/apt-fast.conf", "a") as myfile:
-        myfile.write(f'{advert}MIRRORS=({quote(",".join(mirrors))})')
+    print("MIRRORS not found. Adding it to /etc/apt-fast.conf.")
+    new_content.append(advert)
+    new_content.append('MIRRORS=(' + ' '.join(quote(mirror) for mirror in mirrors) + ' )')
+
+print("The following mirrors have been added to your MIRRORS:")
+for mirror in mirrors:
+    print(mirror)
+
+# rewrite the /etc/apt-fast.conf file with the updated content
+with open("/etc/apt-fast.conf", "w") as f:
+    for line in new_content:
+        print(line, file=f)
+
+print("Your /etc/apt-fast.conf has been successfully updated.")


### PR DESCRIPTION
replaces the direct use of the `lsb_release` Python module, which isn't universally available, with subprocess calls to `lsb_release`.

updated to include comments throughout.

key changes:
- utilize `subprocess.check_output` to execute `lsb_release -a`
- switched from `testing` to `stable`, this is just preference
- utilize `match` for updating MIRRORS list
- uses latest stable `netselect` version
- 